### PR TITLE
Fix delete CLI option

### DIFF
--- a/src/main/scala/com/arya/cli/CliArgs.scala
+++ b/src/main/scala/com/arya/cli/CliArgs.scala
@@ -23,6 +23,6 @@ object CliArgs {
 
   val delKeyOpts: Opts[String] = Opts.option[String]("key", "Fetches value for given key")
   val delOpts: Opts[Del] = Opts.subcommand("del", "Delete key and its value from kvstore") {
-    getKeyOpts.map(Del)
+    delKeyOpts.map(Del)
   }
 }


### PR DESCRIPTION
## Summary
- use the del option parser in the CLI instead of the get parser

## Testing
- `sbt -no-colors compile` *(fails: sbt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b52ad9964833098531dda43cf6257