### PR TITLE
Add CLI argument tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ lazy val cacheService = (project in file(".")).settings(
     "com.monovore" %% "decline-effect" % "2.2.0",
     "dev.profunktor" %% "redis4cats-effects" % "1.0.0",
     "dev.profunktor" %% "redis4cats-log4cats" % "1.0.0",
-    "org.typelevel" %% "log4cats-slf4j" % "2.1.1"
+    "org.typelevel" %% "log4cats-slf4j" % "2.1.1",
+    "org.scalatest" %% "scalatest" % "3.2.17" % Test
   ),
   mainClass := Some("com.arya.cli.Cli"),
   assembly / mainClass := Some("com.arya.cli.Cli"),

--- a/src/main/scala/com/arya/cli/CliArgs.scala
+++ b/src/main/scala/com/arya/cli/CliArgs.scala
@@ -23,6 +23,6 @@ object CliArgs {
 
   val delKeyOpts: Opts[String] = Opts.option[String]("key", "Fetches value for given key")
   val delOpts: Opts[Del] = Opts.subcommand("del", "Delete key and its value from kvstore") {
-    getKeyOpts.map(Del)
+    delKeyOpts.map(Del)
   }
 }

--- a/src/test/scala/com/arya/cli/CliArgsSpec.scala
+++ b/src/test/scala/com/arya/cli/CliArgsSpec.scala
@@ -1,0 +1,25 @@
+package com.arya.cli
+
+import com.monovore.decline.Command
+import org.scalatest.funsuite.AnyFunSuite
+import com.arya.cli.CliArgs._
+
+class CliArgsSpec extends AnyFunSuite {
+
+  private val cmd = Command("kvstore", "kv store app")(getOpts.orElse(putOpts).orElse(delOpts))
+
+  test("parse get command") {
+    val result = cmd.parse(Seq("get", "--key", "foo"))
+    assert(result == Right(Get("foo")))
+  }
+
+  test("parse put command") {
+    val result = cmd.parse(Seq("put", "--key", "foo", "--value", "bar"))
+    assert(result == Right(Put("foo", "bar")))
+  }
+
+  test("parse del command") {
+    val result = cmd.parse(Seq("del", "--key", "foo"))
+    assert(result == Right(Del("foo")))
+  }
+}


### PR DESCRIPTION
## Summary
- add Scalatest to project dependencies
- add tests for CLI argument parsing
- fix `delOpts` to use `delKeyOpts`

## Testing
- `sbt test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b537d500c833081e6419e8eb88bfa